### PR TITLE
Download the archive from Unikraft mirror

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -39,7 +39,7 @@ $(eval $(call addlib_s,libtlsf,$(CONFIG_LIBTLSF)))
 # Sources
 ################################################################################
 LIBTLSF_VERSION=2.4.6
-LIBTLSF_URL=http://wks.gii.upv.es/tlsf/files/src/TLSF-$(LIBTLSF_VERSION).tbz2
+LIBTLSF_URL=https://releases.unikraft.org/mirrors/libs/tlsf/TLSF-$(LIBTLSF_VERSION).tbz2
 LIBTLSF_DIR=TLSF-$(LIBTLSF_VERSION)
 
 LIBTLSF_PATCHDIR=$(LIBTLSF_BASE)/patches


### PR DESCRIPTION
Download the archive `TLSF-2.4.6.tbz2` from releases.unikraft.org.

Signed-off-by: Simon Kuenzer <simon.kuenzer@neclab.eu>